### PR TITLE
Update to latest rancher + changes needed for v2

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -9,6 +9,12 @@ import (
 	"github.com/rancher/go-rancher/client"
 )
 
+func ApiHandlerFunc(schemas *client.Schemas, f http.HandlerFunc) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		ApiHandler(schemas, f).ServeHTTP(rw, r)
+	}
+}
+
 func ApiHandler(schemas *client.Schemas, f http.Handler) http.Handler {
 	return context.ClearHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if err := CreateApiContext(rw, r, schemas); err != nil {

--- a/client/generated_account.go
+++ b/client/generated_account.go
@@ -17,6 +17,8 @@ type Account struct {
 
 	ExternalIdType string `json:"externalIdType,omitempty" yaml:"external_id_type,omitempty"`
 
+	Identity string `json:"identity,omitempty" yaml:"identity,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/client/generated_client.go
+++ b/client/generated_client.go
@@ -47,6 +47,7 @@ type RancherClient struct {
 	LoadBalancerService                      LoadBalancerServiceOperations
 	ExternalService                          ExternalServiceOperations
 	DnsService                               DnsServiceOperations
+	KubernetesService                        KubernetesServiceOperations
 	LaunchConfig                             LaunchConfigOperations
 	SecondaryLaunchConfig                    SecondaryLaunchConfigOperations
 	AddRemoveLoadBalancerServiceLinkInput    AddRemoveLoadBalancerServiceLinkInputOperations
@@ -60,7 +61,6 @@ type RancherClient struct {
 	ExternalDnsEvent                         ExternalDnsEventOperations
 	ExternalHostEvent                        ExternalHostEventOperations
 	LoadBalancerConfig                       LoadBalancerConfigOperations
-	MachineDriverUpdateInput                 MachineDriverUpdateInputOperations
 	MachineDriverErrorInput                  MachineDriverErrorInputOperations
 	Account                                  AccountOperations
 	Agent                                    AgentOperations
@@ -107,6 +107,8 @@ type RancherClient struct {
 	FieldDocumentation                       FieldDocumentationOperations
 	ContainerExec                            ContainerExecOperations
 	ContainerLogs                            ContainerLogsOperations
+	ContainerProxy                           ContainerProxyOperations
+	ServiceProxy                             ServiceProxyOperations
 	HostAccess                               HostAccessOperations
 	DockerBuild                              DockerBuildOperations
 	ActiveSetting                            ActiveSettingOperations
@@ -179,6 +181,7 @@ func constructClient() *RancherClient {
 	client.LoadBalancerService = newLoadBalancerServiceClient(client)
 	client.ExternalService = newExternalServiceClient(client)
 	client.DnsService = newDnsServiceClient(client)
+	client.KubernetesService = newKubernetesServiceClient(client)
 	client.LaunchConfig = newLaunchConfigClient(client)
 	client.SecondaryLaunchConfig = newSecondaryLaunchConfigClient(client)
 	client.AddRemoveLoadBalancerServiceLinkInput = newAddRemoveLoadBalancerServiceLinkInputClient(client)
@@ -192,7 +195,6 @@ func constructClient() *RancherClient {
 	client.ExternalDnsEvent = newExternalDnsEventClient(client)
 	client.ExternalHostEvent = newExternalHostEventClient(client)
 	client.LoadBalancerConfig = newLoadBalancerConfigClient(client)
-	client.MachineDriverUpdateInput = newMachineDriverUpdateInputClient(client)
 	client.MachineDriverErrorInput = newMachineDriverErrorInputClient(client)
 	client.Account = newAccountClient(client)
 	client.Agent = newAgentClient(client)
@@ -239,6 +241,8 @@ func constructClient() *RancherClient {
 	client.FieldDocumentation = newFieldDocumentationClient(client)
 	client.ContainerExec = newContainerExecClient(client)
 	client.ContainerLogs = newContainerLogsClient(client)
+	client.ContainerProxy = newContainerProxyClient(client)
+	client.ServiceProxy = newServiceProxyClient(client)
 	client.HostAccess = newHostAccessClient(client)
 	client.DockerBuild = newDockerBuildClient(client)
 	client.ActiveSetting = newActiveSettingClient(client)

--- a/client/generated_cluster.go
+++ b/client/generated_cluster.go
@@ -39,7 +39,7 @@ type Cluster struct {
 
 	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
 
-	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+	PublicEndpoints []PublicEndpoint `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
 

--- a/client/generated_container.go
+++ b/client/generated_container.go
@@ -174,11 +174,15 @@ type ContainerOperations interface {
 
 	ActionDeallocate(*Container) (*Instance, error)
 
+	ActionError(*Container) (*Instance, error)
+
 	ActionExecute(*Container, *ContainerExec) (*HostAccess, error)
 
 	ActionLogs(*Container, *ContainerLogs) (*HostAccess, error)
 
 	ActionMigrate(*Container) (*Instance, error)
+
+	ActionProxy(*Container, *ContainerProxy) (*HostAccess, error)
 
 	ActionPurge(*Container) (*Instance, error)
 
@@ -278,6 +282,15 @@ func (c *ContainerClient) ActionDeallocate(resource *Container) (*Instance, erro
 	return resp, err
 }
 
+func (c *ContainerClient) ActionError(resource *Container) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *ContainerClient) ActionExecute(resource *Container, input *ContainerExec) (*HostAccess, error) {
 
 	resp := &HostAccess{}
@@ -301,6 +314,15 @@ func (c *ContainerClient) ActionMigrate(resource *Container) (*Instance, error) 
 	resp := &Instance{}
 
 	err := c.rancherClient.doAction(CONTAINER_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ContainerClient) ActionProxy(resource *Container, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(CONTAINER_TYPE, "proxy", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/client/generated_container_proxy.go
+++ b/client/generated_container_proxy.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	CONTAINER_PROXY_TYPE = "containerProxy"
+)
+
+type ContainerProxy struct {
+	Resource
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	Scheme string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+}
+
+type ContainerProxyCollection struct {
+	Collection
+	Data []ContainerProxy `json:"data,omitempty"`
+}
+
+type ContainerProxyClient struct {
+	rancherClient *RancherClient
+}
+
+type ContainerProxyOperations interface {
+	List(opts *ListOpts) (*ContainerProxyCollection, error)
+	Create(opts *ContainerProxy) (*ContainerProxy, error)
+	Update(existing *ContainerProxy, updates interface{}) (*ContainerProxy, error)
+	ById(id string) (*ContainerProxy, error)
+	Delete(container *ContainerProxy) error
+}
+
+func newContainerProxyClient(rancherClient *RancherClient) *ContainerProxyClient {
+	return &ContainerProxyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ContainerProxyClient) Create(container *ContainerProxy) (*ContainerProxy, error) {
+	resp := &ContainerProxy{}
+	err := c.rancherClient.doCreate(CONTAINER_PROXY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ContainerProxyClient) Update(existing *ContainerProxy, updates interface{}) (*ContainerProxy, error) {
+	resp := &ContainerProxy{}
+	err := c.rancherClient.doUpdate(CONTAINER_PROXY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ContainerProxyClient) List(opts *ListOpts) (*ContainerProxyCollection, error) {
+	resp := &ContainerProxyCollection{}
+	err := c.rancherClient.doList(CONTAINER_PROXY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ContainerProxyClient) ById(id string) (*ContainerProxy, error) {
+	resp := &ContainerProxy{}
+	err := c.rancherClient.doById(CONTAINER_PROXY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ContainerProxyClient) Delete(container *ContainerProxy) error {
+	return c.rancherClient.doResourceDelete(CONTAINER_PROXY_TYPE, &container.Resource)
+}

--- a/client/generated_dns_service.go
+++ b/client/generated_dns_service.go
@@ -9,6 +9,8 @@ type DnsService struct {
 
 	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
 
+	AssignServiceIpAddress bool `json:"assignServiceIpAddress,omitempty" yaml:"assign_service_ip_address,omitempty"`
+
 	Created string `json:"created,omitempty" yaml:"created,omitempty"`
 
 	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
@@ -20,6 +22,8 @@ type DnsService struct {
 	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
 
 	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
 
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
@@ -45,7 +49,7 @@ type DnsService struct {
 
 	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
 
-	Upgrade ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
 
 	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }

--- a/client/generated_environment.go
+++ b/client/generated_environment.go
@@ -21,6 +21,8 @@ type Environment struct {
 
 	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
 
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/client/generated_extension_point.go
+++ b/client/generated_extension_point.go
@@ -9,7 +9,7 @@ type ExtensionPoint struct {
 
 	ExcludeSetting string `json:"excludeSetting,omitempty" yaml:"exclude_setting,omitempty"`
 
-	Implementations []interface{} `json:"implementations,omitempty" yaml:"implementations,omitempty"`
+	Implementations []ExtensionImplementation `json:"implementations,omitempty" yaml:"implementations,omitempty"`
 
 	IncludeSetting string `json:"includeSetting,omitempty" yaml:"include_setting,omitempty"`
 

--- a/client/generated_external_handler.go
+++ b/client/generated_external_handler.go
@@ -19,7 +19,7 @@ type ExternalHandler struct {
 
 	Priority int64 `json:"priority,omitempty" yaml:"priority,omitempty"`
 
-	ProcessConfigs []interface{} `json:"processConfigs,omitempty" yaml:"process_configs,omitempty"`
+	ProcessConfigs []ExternalHandlerProcessConfig `json:"processConfigs,omitempty" yaml:"process_configs,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
 

--- a/client/generated_external_service.go
+++ b/client/generated_external_service.go
@@ -25,6 +25,8 @@ type ExternalService struct {
 
 	HealthCheck *InstanceHealthCheck `json:"healthCheck,omitempty" yaml:"health_check,omitempty"`
 
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
 	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
 
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
@@ -47,7 +49,7 @@ type ExternalService struct {
 
 	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
 
-	Upgrade ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
 
 	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }

--- a/client/generated_githubconfig.go
+++ b/client/generated_githubconfig.go
@@ -9,7 +9,7 @@ type Githubconfig struct {
 
 	AccessMode string `json:"accessMode,omitempty" yaml:"access_mode,omitempty"`
 
-	AllowedIdentities []interface{} `json:"allowedIdentities,omitempty" yaml:"allowed_identities,omitempty"`
+	AllowedIdentities []Identity `json:"allowedIdentities,omitempty" yaml:"allowed_identities,omitempty"`
 
 	ClientId string `json:"clientId,omitempty" yaml:"client_id,omitempty"`
 

--- a/client/generated_host.go
+++ b/client/generated_host.go
@@ -35,7 +35,7 @@ type Host struct {
 
 	PhysicalHostId string `json:"physicalHostId,omitempty" yaml:"physical_host_id,omitempty"`
 
-	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+	PublicEndpoints []PublicEndpoint `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
 

--- a/client/generated_in_service_upgrade_strategy.go
+++ b/client/generated_in_service_upgrade_strategy.go
@@ -15,9 +15,9 @@ type InServiceUpgradeStrategy struct {
 
 	PreviousLaunchConfig *LaunchConfig `json:"previousLaunchConfig,omitempty" yaml:"previous_launch_config,omitempty"`
 
-	PreviousSecondaryLaunchConfigs []interface{} `json:"previousSecondaryLaunchConfigs,omitempty" yaml:"previous_secondary_launch_configs,omitempty"`
+	PreviousSecondaryLaunchConfigs []SecondaryLaunchConfig `json:"previousSecondaryLaunchConfigs,omitempty" yaml:"previous_secondary_launch_configs,omitempty"`
 
-	SecondaryLaunchConfigs []interface{} `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
+	SecondaryLaunchConfigs []SecondaryLaunchConfig `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
 
 	StartFirst bool `json:"startFirst,omitempty" yaml:"start_first,omitempty"`
 }

--- a/client/generated_instance.go
+++ b/client/generated_instance.go
@@ -60,6 +60,8 @@ type InstanceOperations interface {
 
 	ActionDeallocate(*Instance) (*Instance, error)
 
+	ActionError(*Instance) (*Instance, error)
+
 	ActionMigrate(*Instance) (*Instance, error)
 
 	ActionPurge(*Instance) (*Instance, error)
@@ -154,6 +156,15 @@ func (c *InstanceClient) ActionDeallocate(resource *Instance) (*Instance, error)
 	resp := &Instance{}
 
 	err := c.rancherClient.doAction(INSTANCE_TYPE, "deallocate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *InstanceClient) ActionError(resource *Instance) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(INSTANCE_TYPE, "error", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/client/generated_kubernetes_service.go
+++ b/client/generated_kubernetes_service.go
@@ -1,0 +1,257 @@
+package client
+
+const (
+	KUBERNETES_SERVICE_TYPE = "kubernetesService"
+)
+
+type KubernetesService struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
+
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
+
+	SelectorContainer string `json:"selectorContainer,omitempty" yaml:"selector_container,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Template interface{} `json:"template,omitempty" yaml:"template,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+
+	Vip string `json:"vip,omitempty" yaml:"vip,omitempty"`
+}
+
+type KubernetesServiceCollection struct {
+	Collection
+	Data []KubernetesService `json:"data,omitempty"`
+}
+
+type KubernetesServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type KubernetesServiceOperations interface {
+	List(opts *ListOpts) (*KubernetesServiceCollection, error)
+	Create(opts *KubernetesService) (*KubernetesService, error)
+	Update(existing *KubernetesService, updates interface{}) (*KubernetesService, error)
+	ById(id string) (*KubernetesService, error)
+	Delete(container *KubernetesService) error
+
+	ActionActivate(*KubernetesService) (*Service, error)
+
+	ActionAddservicelink(*KubernetesService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionCancelrollback(*KubernetesService) (*Service, error)
+
+	ActionCancelupgrade(*KubernetesService) (*Service, error)
+
+	ActionCreate(*KubernetesService) (*Service, error)
+
+	ActionDeactivate(*KubernetesService) (*Service, error)
+
+	ActionFinishupgrade(*KubernetesService) (*Service, error)
+
+	ActionRemove(*KubernetesService) (*Service, error)
+
+	ActionRemoveservicelink(*KubernetesService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionRestart(*KubernetesService, *ServiceRestart) (*Service, error)
+
+	ActionRollback(*KubernetesService) (*Service, error)
+
+	ActionSetservicelinks(*KubernetesService, *SetServiceLinksInput) (*Service, error)
+
+	ActionUpdate(*KubernetesService) (*Service, error)
+
+	ActionUpgrade(*KubernetesService, *ServiceUpgrade) (*Service, error)
+}
+
+func newKubernetesServiceClient(rancherClient *RancherClient) *KubernetesServiceClient {
+	return &KubernetesServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *KubernetesServiceClient) Create(container *KubernetesService) (*KubernetesService, error) {
+	resp := &KubernetesService{}
+	err := c.rancherClient.doCreate(KUBERNETES_SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) Update(existing *KubernetesService, updates interface{}) (*KubernetesService, error) {
+	resp := &KubernetesService{}
+	err := c.rancherClient.doUpdate(KUBERNETES_SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) List(opts *ListOpts) (*KubernetesServiceCollection, error) {
+	resp := &KubernetesServiceCollection{}
+	err := c.rancherClient.doList(KUBERNETES_SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ById(id string) (*KubernetesService, error) {
+	resp := &KubernetesService{}
+	err := c.rancherClient.doById(KUBERNETES_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) Delete(container *KubernetesService) error {
+	return c.rancherClient.doResourceDelete(KUBERNETES_SERVICE_TYPE, &container.Resource)
+}
+
+func (c *KubernetesServiceClient) ActionActivate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "activate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionAddservicelink(resource *KubernetesService, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionCancelrollback(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionCancelupgrade(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionCreate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionDeactivate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionFinishupgrade(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRemove(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRemoveservicelink(resource *KubernetesService, input *AddRemoveServiceLinkInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRestart(resource *KubernetesService, input *ServiceRestart) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "restart", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionRollback(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionSetservicelinks(resource *KubernetesService, input *SetServiceLinksInput) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "setservicelinks", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionUpdate(resource *KubernetesService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *KubernetesServiceClient) ActionUpgrade(resource *KubernetesService, input *ServiceUpgrade) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(KUBERNETES_SERVICE_TYPE, "upgrade", &resource.Resource, input, resp)
+
+	return resp, err
+}

--- a/client/generated_launch_config.go
+++ b/client/generated_launch_config.go
@@ -47,7 +47,7 @@ type LaunchConfig struct {
 
 	Devices []string `json:"devices,omitempty" yaml:"devices,omitempty"`
 
-	Disks []interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
+	Disks []VirtualMachineDisk `json:"disks,omitempty" yaml:"disks,omitempty"`
 
 	Dns []string `json:"dns,omitempty" yaml:"dns,omitempty"`
 
@@ -121,6 +121,8 @@ type LaunchConfig struct {
 
 	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
 
+	RequestedIpAddress string `json:"requestedIpAddress,omitempty" yaml:"requested_ip_address,omitempty"`
+
 	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
 
 	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
@@ -182,11 +184,15 @@ type LaunchConfigOperations interface {
 
 	ActionDeallocate(*LaunchConfig) (*Instance, error)
 
+	ActionError(*LaunchConfig) (*Instance, error)
+
 	ActionExecute(*LaunchConfig, *ContainerExec) (*HostAccess, error)
 
 	ActionLogs(*LaunchConfig, *ContainerLogs) (*HostAccess, error)
 
 	ActionMigrate(*LaunchConfig) (*Instance, error)
+
+	ActionProxy(*LaunchConfig, *ContainerProxy) (*HostAccess, error)
 
 	ActionPurge(*LaunchConfig) (*Instance, error)
 
@@ -286,6 +292,15 @@ func (c *LaunchConfigClient) ActionDeallocate(resource *LaunchConfig) (*Instance
 	return resp, err
 }
 
+func (c *LaunchConfigClient) ActionError(resource *LaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *LaunchConfigClient) ActionExecute(resource *LaunchConfig, input *ContainerExec) (*HostAccess, error) {
 
 	resp := &HostAccess{}
@@ -309,6 +324,15 @@ func (c *LaunchConfigClient) ActionMigrate(resource *LaunchConfig) (*Instance, e
 	resp := &Instance{}
 
 	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *LaunchConfigClient) ActionProxy(resource *LaunchConfig, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(LAUNCH_CONFIG_TYPE, "proxy", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/client/generated_load_balancer_service.go
+++ b/client/generated_load_balancer_service.go
@@ -9,6 +9,8 @@ type LoadBalancerService struct {
 
 	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
 
+	AssignServiceIpAddress bool `json:"assignServiceIpAddress,omitempty" yaml:"assign_service_ip_address,omitempty"`
+
 	CertificateIds []string `json:"certificateIds,omitempty" yaml:"certificate_ids,omitempty"`
 
 	Created string `json:"created,omitempty" yaml:"created,omitempty"`
@@ -25,6 +27,8 @@ type LoadBalancerService struct {
 
 	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
 
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
@@ -35,7 +39,7 @@ type LoadBalancerService struct {
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
-	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+	PublicEndpoints []PublicEndpoint `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
 
@@ -55,7 +59,7 @@ type LoadBalancerService struct {
 
 	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
 
-	Upgrade ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
 
 	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 

--- a/client/generated_machine_driver.go
+++ b/client/generated_machine_driver.go
@@ -58,13 +58,11 @@ type MachineDriverOperations interface {
 
 	ActionActivate(*MachineDriver) (*MachineDriver, error)
 
-	ActionCreate(*MachineDriver) (*MachineDriver, error)
-
 	ActionError(*MachineDriver, *MachineDriverErrorInput) (*MachineDriver, error)
 
-	ActionPurge(*MachineDriver) (*MachineDriver, error)
-
 	ActionRemove(*MachineDriver) (*MachineDriver, error)
+
+	ActionRetry(*MachineDriver) (*MachineDriver, error)
 
 	ActionUpdate(*MachineDriver, *MachineDriverUpdateInput) (*MachineDriver, error)
 }
@@ -117,15 +115,6 @@ func (c *MachineDriverClient) ActionActivate(resource *MachineDriver) (*MachineD
 	return resp, err
 }
 
-func (c *MachineDriverClient) ActionCreate(resource *MachineDriver) (*MachineDriver, error) {
-
-	resp := &MachineDriver{}
-
-	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "create", &resource.Resource, nil, resp)
-
-	return resp, err
-}
-
 func (c *MachineDriverClient) ActionError(resource *MachineDriver, input *MachineDriverErrorInput) (*MachineDriver, error) {
 
 	resp := &MachineDriver{}
@@ -135,20 +124,20 @@ func (c *MachineDriverClient) ActionError(resource *MachineDriver, input *Machin
 	return resp, err
 }
 
-func (c *MachineDriverClient) ActionPurge(resource *MachineDriver) (*MachineDriver, error) {
-
-	resp := &MachineDriver{}
-
-	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "purge", &resource.Resource, nil, resp)
-
-	return resp, err
-}
-
 func (c *MachineDriverClient) ActionRemove(resource *MachineDriver) (*MachineDriver, error) {
 
 	resp := &MachineDriver{}
 
 	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *MachineDriverClient) ActionRetry(resource *MachineDriver) (*MachineDriver, error) {
+
+	resp := &MachineDriver{}
+
+	err := c.rancherClient.doAction(MACHINE_DRIVER_TYPE, "retry", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/client/generated_process_definition.go
+++ b/client/generated_process_definition.go
@@ -19,7 +19,7 @@ type ProcessDefinition struct {
 
 	ResourceType string `json:"resourceType,omitempty" yaml:"resource_type,omitempty"`
 
-	StateTransitions []interface{} `json:"stateTransitions,omitempty" yaml:"state_transitions,omitempty"`
+	StateTransitions []StateTransition `json:"stateTransitions,omitempty" yaml:"state_transitions,omitempty"`
 }
 
 type ProcessDefinitionCollection struct {

--- a/client/generated_process_execution.go
+++ b/client/generated_process_execution.go
@@ -7,6 +7,8 @@ const (
 type ProcessExecution struct {
 	Resource
 
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
 	Log map[string]interface{} `json:"log,omitempty" yaml:"log,omitempty"`
 
 	ProcessInstanceId string `json:"processInstanceId,omitempty" yaml:"process_instance_id,omitempty"`

--- a/client/generated_project.go
+++ b/client/generated_project.go
@@ -17,7 +17,7 @@ type Project struct {
 
 	Kubernetes bool `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 
-	Members []interface{} `json:"members,omitempty" yaml:"members,omitempty"`
+	Members []ProjectMember `json:"members,omitempty" yaml:"members,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 

--- a/client/generated_secondary_launch_config.go
+++ b/client/generated_secondary_launch_config.go
@@ -47,7 +47,7 @@ type SecondaryLaunchConfig struct {
 
 	Devices []string `json:"devices,omitempty" yaml:"devices,omitempty"`
 
-	Disks []interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
+	Disks []VirtualMachineDisk `json:"disks,omitempty" yaml:"disks,omitempty"`
 
 	Dns []string `json:"dns,omitempty" yaml:"dns,omitempty"`
 
@@ -123,6 +123,8 @@ type SecondaryLaunchConfig struct {
 
 	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
 
+	RequestedIpAddress string `json:"requestedIpAddress,omitempty" yaml:"requested_ip_address,omitempty"`
+
 	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
 
 	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
@@ -184,11 +186,15 @@ type SecondaryLaunchConfigOperations interface {
 
 	ActionDeallocate(*SecondaryLaunchConfig) (*Instance, error)
 
+	ActionError(*SecondaryLaunchConfig) (*Instance, error)
+
 	ActionExecute(*SecondaryLaunchConfig, *ContainerExec) (*HostAccess, error)
 
 	ActionLogs(*SecondaryLaunchConfig, *ContainerLogs) (*HostAccess, error)
 
 	ActionMigrate(*SecondaryLaunchConfig) (*Instance, error)
+
+	ActionProxy(*SecondaryLaunchConfig, *ContainerProxy) (*HostAccess, error)
 
 	ActionPurge(*SecondaryLaunchConfig) (*Instance, error)
 
@@ -288,6 +294,15 @@ func (c *SecondaryLaunchConfigClient) ActionDeallocate(resource *SecondaryLaunch
 	return resp, err
 }
 
+func (c *SecondaryLaunchConfigClient) ActionError(resource *SecondaryLaunchConfig) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *SecondaryLaunchConfigClient) ActionExecute(resource *SecondaryLaunchConfig, input *ContainerExec) (*HostAccess, error) {
 
 	resp := &HostAccess{}
@@ -311,6 +326,15 @@ func (c *SecondaryLaunchConfigClient) ActionMigrate(resource *SecondaryLaunchCon
 	resp := &Instance{}
 
 	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *SecondaryLaunchConfigClient) ActionProxy(resource *SecondaryLaunchConfig, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(SECONDARY_LAUNCH_CONFIG_TYPE, "proxy", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/client/generated_service.go
+++ b/client/generated_service.go
@@ -9,6 +9,8 @@ type Service struct {
 
 	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
 
+	AssignServiceIpAddress bool `json:"assignServiceIpAddress,omitempty" yaml:"assign_service_ip_address,omitempty"`
+
 	CreateIndex int64 `json:"createIndex,omitempty" yaml:"create_index,omitempty"`
 
 	Created string `json:"created,omitempty" yaml:"created,omitempty"`
@@ -23,6 +25,8 @@ type Service struct {
 
 	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
 
+	HealthState string `json:"healthState,omitempty" yaml:"health_state,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
@@ -31,7 +35,7 @@ type Service struct {
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
-	PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+	PublicEndpoints []PublicEndpoint `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
 
@@ -41,13 +45,11 @@ type Service struct {
 
 	Scale int64 `json:"scale,omitempty" yaml:"scale,omitempty"`
 
-	SecondaryLaunchConfigs []interface{} `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
+	SecondaryLaunchConfigs []SecondaryLaunchConfig `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
 
 	SelectorContainer string `json:"selectorContainer,omitempty" yaml:"selector_container,omitempty"`
 
 	SelectorLink string `json:"selectorLink,omitempty" yaml:"selector_link,omitempty"`
-
-	ServiceSchemas map[string]interface{} `json:"serviceSchemas,omitempty" yaml:"service_schemas,omitempty"`
 
 	State string `json:"state,omitempty" yaml:"state,omitempty"`
 
@@ -57,7 +59,7 @@ type Service struct {
 
 	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
 
-	Upgrade ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
+	Upgrade *ServiceUpgrade `json:"upgrade,omitempty" yaml:"upgrade,omitempty"`
 
 	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 

--- a/client/generated_service_proxy.go
+++ b/client/generated_service_proxy.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	SERVICE_PROXY_TYPE = "serviceProxy"
+)
+
+type ServiceProxy struct {
+	Resource
+
+	Port int64 `json:"port,omitempty" yaml:"port,omitempty"`
+
+	Scheme string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+
+	Service string `json:"service,omitempty" yaml:"service,omitempty"`
+
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
+
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+type ServiceProxyCollection struct {
+	Collection
+	Data []ServiceProxy `json:"data,omitempty"`
+}
+
+type ServiceProxyClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceProxyOperations interface {
+	List(opts *ListOpts) (*ServiceProxyCollection, error)
+	Create(opts *ServiceProxy) (*ServiceProxy, error)
+	Update(existing *ServiceProxy, updates interface{}) (*ServiceProxy, error)
+	ById(id string) (*ServiceProxy, error)
+	Delete(container *ServiceProxy) error
+}
+
+func newServiceProxyClient(rancherClient *RancherClient) *ServiceProxyClient {
+	return &ServiceProxyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceProxyClient) Create(container *ServiceProxy) (*ServiceProxy, error) {
+	resp := &ServiceProxy{}
+	err := c.rancherClient.doCreate(SERVICE_PROXY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceProxyClient) Update(existing *ServiceProxy, updates interface{}) (*ServiceProxy, error) {
+	resp := &ServiceProxy{}
+	err := c.rancherClient.doUpdate(SERVICE_PROXY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceProxyClient) List(opts *ListOpts) (*ServiceProxyCollection, error) {
+	resp := &ServiceProxyCollection{}
+	err := c.rancherClient.doList(SERVICE_PROXY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceProxyClient) ById(id string) (*ServiceProxy, error) {
+	resp := &ServiceProxy{}
+	err := c.rancherClient.doById(SERVICE_PROXY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceProxyClient) Delete(container *ServiceProxy) error {
+	return c.rancherClient.doResourceDelete(SERVICE_PROXY_TYPE, &container.Resource)
+}

--- a/client/generated_set_load_balancer_service_links_input.go
+++ b/client/generated_set_load_balancer_service_links_input.go
@@ -7,7 +7,7 @@ const (
 type SetLoadBalancerServiceLinksInput struct {
 	Resource
 
-	ServiceLinks []interface{} `json:"serviceLinks,omitempty" yaml:"service_links,omitempty"`
+	ServiceLinks []LoadBalancerServiceLink `json:"serviceLinks,omitempty" yaml:"service_links,omitempty"`
 }
 
 type SetLoadBalancerServiceLinksInputCollection struct {

--- a/client/generated_set_project_members_input.go
+++ b/client/generated_set_project_members_input.go
@@ -7,7 +7,7 @@ const (
 type SetProjectMembersInput struct {
 	Resource
 
-	Members []interface{} `json:"members,omitempty" yaml:"members,omitempty"`
+	Members []ProjectMember `json:"members,omitempty" yaml:"members,omitempty"`
 }
 
 type SetProjectMembersInputCollection struct {

--- a/client/generated_set_service_links_input.go
+++ b/client/generated_set_service_links_input.go
@@ -7,7 +7,7 @@ const (
 type SetServiceLinksInput struct {
 	Resource
 
-	ServiceLinks []interface{} `json:"serviceLinks,omitempty" yaml:"service_links,omitempty"`
+	ServiceLinks []ServiceLink `json:"serviceLinks,omitempty" yaml:"service_links,omitempty"`
 }
 
 type SetServiceLinksInputCollection struct {

--- a/client/generated_virtual_machine.go
+++ b/client/generated_virtual_machine.go
@@ -31,7 +31,7 @@ type VirtualMachine struct {
 
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
-	Disks []interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
+	Disks []VirtualMachineDisk `json:"disks,omitempty" yaml:"disks,omitempty"`
 
 	Dns []string `json:"dns,omitempty" yaml:"dns,omitempty"`
 
@@ -144,11 +144,15 @@ type VirtualMachineOperations interface {
 
 	ActionDeallocate(*VirtualMachine) (*Instance, error)
 
+	ActionError(*VirtualMachine) (*Instance, error)
+
 	ActionExecute(*VirtualMachine, *ContainerExec) (*HostAccess, error)
 
 	ActionLogs(*VirtualMachine, *ContainerLogs) (*HostAccess, error)
 
 	ActionMigrate(*VirtualMachine) (*Instance, error)
+
+	ActionProxy(*VirtualMachine, *ContainerProxy) (*HostAccess, error)
 
 	ActionPurge(*VirtualMachine) (*Instance, error)
 
@@ -248,6 +252,15 @@ func (c *VirtualMachineClient) ActionDeallocate(resource *VirtualMachine) (*Inst
 	return resp, err
 }
 
+func (c *VirtualMachineClient) ActionError(resource *VirtualMachine) (*Instance, error) {
+
+	resp := &Instance{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "error", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *VirtualMachineClient) ActionExecute(resource *VirtualMachine, input *ContainerExec) (*HostAccess, error) {
 
 	resp := &HostAccess{}
@@ -271,6 +284,15 @@ func (c *VirtualMachineClient) ActionMigrate(resource *VirtualMachine) (*Instanc
 	resp := &Instance{}
 
 	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "migrate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *VirtualMachineClient) ActionProxy(resource *VirtualMachine, input *ContainerProxy) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(VIRTUAL_MACHINE_TYPE, "proxy", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/client/types.go
+++ b/client/types.go
@@ -87,3 +87,11 @@ type Filter struct {
 type ListOpts struct {
 	Filters map[string]interface{}
 }
+
+type ServerApiError struct {
+	Type    string `json:"type"`
+	Status  int    `json:"status"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Detail  string `json:"detail"`
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -71,8 +71,12 @@ func getTypeMap(schema client.Schema) map[string]string {
 				result[fieldName] = "[]int64"
 			case "array[float64]":
 				result[fieldName] = "[]float64"
-			default:
+			case "array[json]":
 				result[fieldName] = "[]interface{}"
+			default:
+				s := strings.TrimLeft(field.Type, "array[")
+				s = strings.TrimRight(s, "]")
+				result[fieldName] = "[]" + capitalize(s)
 			}
 		} else if strings.HasPrefix(field.Type, "map") {
 			result[fieldName] = "map[string]interface{}"

--- a/generator/schemas.json
+++ b/generator/schemas.json
@@ -2597,6 +2597,8 @@
           "maxLength": 128,
           "options": [
             "creating",
+            "error",
+            "erroring",
             "migrating",
             "purged",
             "purging",
@@ -3448,6 +3450,10 @@
           "input": null,
           "output": "instance"
         },
+        "error": {
+          "input": null,
+          "output": "instance"
+        },
         "remove": {
           "input": null,
           "output": "instance"
@@ -3502,6 +3508,10 @@
         },
         "execute": {
           "input": "containerExec",
+          "output": "hostAccess"
+        },
+        "proxy": {
+          "input": "containerProxy",
           "output": "hostAccess"
         }
       },
@@ -5642,6 +5652,8 @@
           "maxLength": 128,
           "options": [
             "creating",
+            "error",
+            "erroring",
             "migrating",
             "purged",
             "purging",
@@ -6155,6 +6167,10 @@
           "input": null,
           "output": "instance"
         },
+        "error": {
+          "input": null,
+          "output": "instance"
+        },
         "remove": {
           "input": null,
           "output": "instance"
@@ -6210,6 +6226,10 @@
         "execute": {
           "input": "containerExec",
           "output": "hostAccess"
+        },
+        "proxy": {
+          "input": "containerProxy",
+          "output": "hostAccess"
         }
       },
       "collectionActions": {},
@@ -6242,6 +6262,14 @@
           "nullable": true,
           "readOnCreateOnly": false,
           "maxLength": 255
+        },
+        "assignServiceIpAddress": {
+          "type": "boolean",
+          "description": null,
+          "create": true,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
         },
         "created": {
           "type": "date",
@@ -6295,6 +6323,15 @@
           "update": false,
           "nullable": true,
           "readOnCreateOnly": false
+        },
+        "healthState": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 128
         },
         "id": {
           "type": "int",
@@ -6454,6 +6491,7 @@
           "description": null,
           "create": false,
           "update": false,
+          "nullable": true,
           "readOnCreateOnly": false
         },
         "uuid": {
@@ -6552,6 +6590,17 @@
           ]
         },
         "externalId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "healthState": {
           "modifiers": [
             "eq",
             "ne",
@@ -6825,6 +6874,15 @@
           "nullable": true,
           "readOnCreateOnly": false
         },
+        "healthState": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 128
+        },
         "id": {
           "type": "int",
           "description": null,
@@ -6950,6 +7008,7 @@
           "description": null,
           "create": false,
           "update": false,
+          "nullable": true,
           "readOnCreateOnly": false
         },
         "uuid": {
@@ -7039,6 +7098,17 @@
           ]
         },
         "externalId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "healthState": {
           "modifiers": [
             "eq",
             "ne",
@@ -7259,6 +7329,14 @@
           "readOnCreateOnly": false,
           "maxLength": 255
         },
+        "assignServiceIpAddress": {
+          "type": "boolean",
+          "description": null,
+          "create": true,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
+        },
         "created": {
           "type": "date",
           "description": null,
@@ -7311,6 +7389,15 @@
           "update": false,
           "nullable": true,
           "readOnCreateOnly": false
+        },
+        "healthState": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 128
         },
         "id": {
           "type": "int",
@@ -7454,6 +7541,7 @@
           "description": null,
           "create": false,
           "update": false,
+          "nullable": true,
           "readOnCreateOnly": false
         },
         "uuid": {
@@ -7519,6 +7607,17 @@
           ]
         },
         "externalId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "healthState": {
           "modifiers": [
             "eq",
             "ne",
@@ -7718,6 +7817,480 @@
       "collectionMethods": [
         "GET",
         "POST"
+      ]
+    },
+    {
+      "id": "kubernetesService",
+      "type": "schema",
+      "links": {
+        "self": "http://localhost:8080/v1/schemas/kubernetesservice",
+        "collection": "http://localhost:8080/v1/kubernetesservices"
+      },
+      "actions": {},
+      "pluralName": "kubernetesServices",
+      "resourceFields": {
+        "accountId": {
+          "type": "reference[account]",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "created": {
+          "type": "date",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "data": {
+          "type": "map[json]",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 16777215
+        },
+        "description": {
+          "type": "string",
+          "description": null,
+          "create": true,
+          "update": true,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 1024
+        },
+        "environmentId": {
+          "type": "reference[environment]",
+          "description": null,
+          "create": true,
+          "update": false,
+          "required": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "externalId": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "healthState": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 128
+        },
+        "id": {
+          "type": "int",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
+        },
+        "kind": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "name": {
+          "type": "string",
+          "validChars": "a-zA-Z0-9-",
+          "description": null,
+          "create": true,
+          "update": true,
+          "nullable": true,
+          "required": true,
+          "readOnCreateOnly": false,
+          "minLength": 1,
+          "maxLength": 63
+        },
+        "removeTime": {
+          "type": "date",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "removed": {
+          "type": "date",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "selectorContainer": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 4096
+        },
+        "state": {
+          "type": "enum",
+          "description": null,
+          "create": false,
+          "update": false,
+          "readOnCreateOnly": false,
+          "maxLength": 128,
+          "options": [
+            "activating",
+            "active",
+            "canceled-rollback",
+            "canceled-upgrade",
+            "canceling-rollback",
+            "canceling-upgrade",
+            "deactivating",
+            "finishing-upgrade",
+            "inactive",
+            "registering",
+            "removed",
+            "removing",
+            "requested",
+            "restarting",
+            "rolling-back",
+            "updating-active",
+            "updating-inactive",
+            "upgraded",
+            "upgrading"
+          ]
+        },
+        "transitioning": {
+          "type": "enum",
+          "description": null,
+          "create": false,
+          "update": false,
+          "readOnCreateOnly": false,
+          "options": [
+            "yes",
+            "no",
+            "error"
+          ]
+        },
+        "transitioningMessage": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
+        },
+        "transitioningProgress": {
+          "type": "int",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
+        },
+        "uuid": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 128
+        },
+        "vip": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
+        "template": {
+          "type": "json",
+          "description": null,
+          "create": false,
+          "update": false,
+          "readOnCreateOnly": false
+        }
+      },
+      "collectionFilters": {
+        "accountId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "null",
+            "notnull"
+          ]
+        },
+        "createIndex": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "null",
+            "notnull"
+          ]
+        },
+        "created": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "null",
+            "notnull"
+          ]
+        },
+        "description": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "environmentId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "null",
+            "notnull"
+          ]
+        },
+        "externalId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "healthState": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "id": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "null",
+            "notnull"
+          ]
+        },
+        "kind": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "name": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "removeTime": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "null",
+            "notnull"
+          ]
+        },
+        "removed": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "null",
+            "notnull"
+          ]
+        },
+        "selectorContainer": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "selectorLink": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "state": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "null",
+            "notnull"
+          ]
+        },
+        "uuid": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "vip": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        }
+      },
+      "includeableLinks": [
+        "dynamicschemas",
+        "environment",
+        "consumedservices",
+        "configitemstatuses",
+        "serviceexposemaps",
+        "account",
+        "instances",
+        "consumedbyservices"
+      ],
+      "resourceActions": {
+        "update": {
+          "input": null,
+          "output": "service"
+        },
+        "finishupgrade": {
+          "input": null,
+          "output": "service"
+        },
+        "restart": {
+          "input": "serviceRestart",
+          "output": "service"
+        },
+        "remove": {
+          "input": null,
+          "output": "service"
+        },
+        "setservicelinks": {
+          "input": "setServiceLinksInput",
+          "output": "service"
+        },
+        "cancelupgrade": {
+          "input": null,
+          "output": "service"
+        },
+        "removeservicelink": {
+          "input": "addRemoveServiceLinkInput",
+          "output": "service"
+        },
+        "rollback": {
+          "input": null,
+          "output": "service"
+        },
+        "create": {
+          "input": null,
+          "output": "service"
+        },
+        "activate": {
+          "input": null,
+          "output": "service"
+        },
+        "upgrade": {
+          "input": "serviceUpgrade",
+          "output": "service"
+        },
+        "deactivate": {
+          "input": null,
+          "output": "service"
+        },
+        "addservicelink": {
+          "input": "addRemoveServiceLinkInput",
+          "output": "service"
+        },
+        "cancelrollback": {
+          "input": null,
+          "output": "service"
+        }
+      },
+      "collectionActions": {},
+      "collectionFields": {},
+      "resourceMethods": [
+        "GET"
+      ],
+      "collectionMethods": [
+        "GET"
       ]
     },
     {
@@ -8288,6 +8861,14 @@
           "nullable": true,
           "readOnCreateOnly": false
         },
+        "requestedIpAddress": {
+          "type": "string",
+          "description": null,
+          "create": true,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
+        },
         "securityOpt": {
           "type": "array[string]",
           "description": null,
@@ -8322,6 +8903,8 @@
           "maxLength": 128,
           "options": [
             "creating",
+            "error",
+            "erroring",
             "migrating",
             "purged",
             "purging",
@@ -8886,6 +9469,10 @@
           "input": null,
           "output": "instance"
         },
+        "error": {
+          "input": null,
+          "output": "instance"
+        },
         "remove": {
           "input": null,
           "output": "instance"
@@ -8940,6 +9527,10 @@
         },
         "execute": {
           "input": "containerExec",
+          "output": "hostAccess"
+        },
+        "proxy": {
+          "input": "containerProxy",
           "output": "hostAccess"
         }
       },
@@ -9467,8 +10058,7 @@
             "host",
             "managed",
             "container"
-          ],
-          "default": "managed"
+          ]
         },
         "pidMode": {
           "type": "enum",
@@ -9555,6 +10145,14 @@
           "nullable": true,
           "readOnCreateOnly": false
         },
+        "requestedIpAddress": {
+          "type": "string",
+          "description": null,
+          "create": true,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
+        },
         "securityOpt": {
           "type": "array[string]",
           "description": null,
@@ -9589,6 +10187,8 @@
           "maxLength": 128,
           "options": [
             "creating",
+            "error",
+            "erroring",
             "migrating",
             "purged",
             "purging",
@@ -10129,6 +10729,10 @@
           "input": null,
           "output": "instance"
         },
+        "error": {
+          "input": null,
+          "output": "instance"
+        },
         "remove": {
           "input": null,
           "output": "instance"
@@ -10183,6 +10787,10 @@
         },
         "execute": {
           "input": "containerExec",
+          "output": "hostAccess"
+        },
+        "proxy": {
+          "input": "containerProxy",
           "output": "hostAccess"
         }
       },
@@ -12081,52 +12689,6 @@
       ]
     },
     {
-      "id": "machineDriverUpdateInput",
-      "type": "schema",
-      "links": {
-        "self": "http://localhost:8080/v1/schemas/machinedriverupdateinput"
-      },
-      "actions": {},
-      "pluralName": "machineDriverUpdateInputs",
-      "resourceFields": {
-        "uri": {
-          "type": "string",
-          "description": null,
-          "create": true,
-          "update": false,
-          "nullable": true,
-          "readOnCreateOnly": false
-        },
-        "name": {
-          "type": "string",
-          "description": null,
-          "create": true,
-          "update": false,
-          "nullable": true,
-          "readOnCreateOnly": false
-        },
-        "md5checksum": {
-          "type": "string",
-          "description": null,
-          "create": true,
-          "update": false,
-          "nullable": true,
-          "readOnCreateOnly": false
-        }
-      },
-      "collectionFilters": {},
-      "includeableLinks": [],
-      "resourceActions": {},
-      "collectionActions": {},
-      "collectionFields": {},
-      "resourceMethods": [
-        "GET"
-      ],
-      "collectionMethods": [
-        "POST"
-      ]
-    },
-    {
       "id": "machineDriverErrorInput",
       "type": "schema",
       "links": {
@@ -12314,6 +12876,13 @@
           "create": false,
           "update": false,
           "nullable": true,
+          "readOnCreateOnly": false
+        },
+        "identity": {
+          "type": "reference[identity]",
+          "description": null,
+          "create": false,
+          "update": false,
           "readOnCreateOnly": false
         }
       },
@@ -15252,6 +15821,15 @@
           "readOnCreateOnly": false,
           "maxLength": 128
         },
+        "healthState": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 128
+        },
         "id": {
           "type": "int",
           "description": null,
@@ -15440,6 +16018,17 @@
           ]
         },
         "externalId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "healthState": {
           "modifiers": [
             "eq",
             "ne",
@@ -18125,6 +18714,8 @@
           "maxLength": 128,
           "options": [
             "creating",
+            "error",
+            "erroring",
             "migrating",
             "purged",
             "purging",
@@ -18568,6 +19159,10 @@
           "output": "instance"
         },
         "updatereinitializing": {
+          "input": null,
+          "output": "instance"
+        },
+        "error": {
           "input": null,
           "output": "instance"
         },
@@ -19838,17 +20433,13 @@
           "options": [
             "activating",
             "active",
-            "creating",
+            "create",
             "error",
             "erroring",
-            "inactive",
-            "purged",
-            "purging",
-            "registering",
             "removed",
             "removing",
             "requested",
-            "updating"
+            "requesting"
           ]
         },
         "uri": {
@@ -20057,11 +20648,7 @@
           "input": "machineDriverErrorInput",
           "output": "machineDriver"
         },
-        "create": {
-          "input": null,
-          "output": "machineDriver"
-        },
-        "purge": {
+        "retry": {
           "input": null,
           "output": "machineDriver"
         }
@@ -20070,7 +20657,6 @@
       "collectionFields": {},
       "resourceMethods": [
         "GET",
-        "PUT",
         "DELETE"
       ],
       "collectionMethods": [
@@ -21529,6 +22115,15 @@
       "actions": {},
       "pluralName": "processExecutions",
       "resourceFields": {
+        "created": {
+          "type": "date",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 255
+        },
         "id": {
           "type": "int",
           "description": null,
@@ -21565,6 +22160,18 @@
         }
       },
       "collectionFilters": {
+        "created": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "null",
+            "notnull"
+          ]
+        },
         "id": {
           "modifiers": [
             "eq",
@@ -22349,6 +22956,15 @@
           "readOnCreateOnly": false,
           "maxLength": 255
         },
+        "healthState": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "maxLength": 128
+        },
         "id": {
           "type": "int",
           "description": null,
@@ -22510,6 +23126,7 @@
           "description": null,
           "create": false,
           "update": false,
+          "nullable": true,
           "readOnCreateOnly": false
         },
         "secondaryLaunchConfigs": {
@@ -22535,14 +23152,6 @@
           "nullable": true,
           "readOnCreateOnly": false
         },
-        "serviceSchemas": {
-          "type": "map[schema]",
-          "description": null,
-          "create": true,
-          "update": false,
-          "nullable": true,
-          "readOnCreateOnly": false
-        },
         "publicEndpoints": {
           "type": "array[publicEndpoint]",
           "description": null,
@@ -22552,6 +23161,14 @@
           "readOnCreateOnly": false
         },
         "retainIp": {
+          "type": "boolean",
+          "description": null,
+          "create": true,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false
+        },
+        "assignServiceIpAddress": {
           "type": "boolean",
           "description": null,
           "create": true,
@@ -22613,6 +23230,17 @@
           ]
         },
         "externalId": {
+          "modifiers": [
+            "eq",
+            "ne",
+            "prefix",
+            "like",
+            "notlike",
+            "null",
+            "notnull"
+          ]
+        },
+        "healthState": {
           "modifiers": [
             "eq",
             "ne",
@@ -25596,6 +26224,124 @@
         "GET"
       ],
       "collectionMethods": [
+        "POST"
+      ]
+    },
+    {
+      "id": "containerProxy",
+      "type": "schema",
+      "links": {
+        "self": "http://localhost:8080/v1/schemas/containerproxy"
+      },
+      "actions": {},
+      "pluralName": "containerProxys",
+      "resourceFields": {
+        "port": {
+          "type": "int",
+          "transform": "",
+          "description": null,
+          "create": true,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "min": 0,
+          "default": 80
+        },
+        "scheme": {
+          "type": "enum",
+          "transform": "",
+          "description": null,
+          "create": true,
+          "update": false,
+          "readOnCreateOnly": false,
+          "options": [
+            "http",
+            "https"
+          ],
+          "default": "http"
+        }
+      },
+      "collectionFilters": {},
+      "includeableLinks": [],
+      "resourceActions": {},
+      "collectionActions": {},
+      "collectionFields": {},
+      "resourceMethods": [
+        "GET"
+      ],
+      "collectionMethods": [
+        "POST"
+      ]
+    },
+    {
+      "id": "serviceProxy",
+      "type": "schema",
+      "links": {
+        "self": "http://localhost:8080/v1/schemas/serviceproxy",
+        "collection": "http://localhost:8080/v1/serviceproxies"
+      },
+      "actions": {},
+      "pluralName": "serviceProxies",
+      "resourceFields": {
+        "port": {
+          "type": "int",
+          "transform": "",
+          "description": null,
+          "create": true,
+          "update": false,
+          "nullable": true,
+          "readOnCreateOnly": false,
+          "min": 0,
+          "default": 80
+        },
+        "scheme": {
+          "type": "enum",
+          "transform": "",
+          "description": null,
+          "create": true,
+          "update": false,
+          "readOnCreateOnly": false,
+          "options": [
+            "http",
+            "https"
+          ],
+          "default": "http"
+        },
+        "service": {
+          "type": "string",
+          "transform": "",
+          "description": null,
+          "create": true,
+          "update": false,
+          "required": true,
+          "readOnCreateOnly": false,
+          "minLength": 1
+        },
+        "token": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "readOnCreateOnly": false
+        },
+        "url": {
+          "type": "string",
+          "description": null,
+          "create": false,
+          "update": false,
+          "readOnCreateOnly": false
+        }
+      },
+      "collectionFilters": {},
+      "includeableLinks": [],
+      "resourceActions": {},
+      "collectionActions": {},
+      "collectionFields": {},
+      "resourceMethods": [
+        "GET"
+      ],
+      "collectionMethods": [
+        "GET",
         "POST"
       ]
     },


### PR DESCRIPTION
Schema to the latest rancher
Also changed schema builder to put the concrete type instead of interface{} for non-reference array elements. 

Example:

```
PublicEndpoints []interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
```

will be 

```
PublicEndpoints []PublicEndpoint `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
```