### PR TITLE
Fix to add the field of type Struct to the Schemas.

### DIFF
--- a/client/schemas.go
+++ b/client/schemas.go
@@ -75,6 +75,9 @@ func typeToFields(t reflect.Type) map[string]Field {
 		case fieldString == "slice":
 			// HACK
 			schemaField.Type = "array[string]"
+		case fieldString == "struct":
+			schemaField.Type = typeField.Type.String()
+
 		}
 
 		name := strings.Split(typeField.Tag.Get("json"), ",")[0]


### PR DESCRIPTION
Fields of type Struct which are defined inside a schema resource type, are getting skipped and so they do not show up in the api ui responses.

Fixed the schema-building part to also add the struct types.