### PR TITLE
Use passed URL as schemasURL when is has /schemas suffix

### DIFF
--- a/catalog/common.go
+++ b/catalog/common.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -151,9 +152,14 @@ func setupRancherBaseClient(rancherClient *RancherBaseClientImpl, opts *ClientOp
 		return newApiError(resp, opts.Url)
 	}
 
-	schemasUrls := resp.Header.Get("X-API-Schemas")
-	if len(schemasUrls) == 0 {
-		return errors.New("Failed to find schema at [" + opts.Url + "]")
+	var schemasUrls string
+	if strings.HasSuffix(opts.Url, "/schemas") {
+		schemasUrls = opts.Url
+	} else {
+		schemasUrls = resp.Header.Get("X-API-Schemas")
+		if len(schemasUrls) == 0 {
+			return errors.New("Failed to find schema at [" + opts.Url + "]")
+		}
 	}
 
 	if schemasUrls != opts.Url {


### PR DESCRIPTION
The `X-API-Schemas` headers returned by `/v1-catalog` and child nodes is always `/v1`, so it's not possible to access the schemas.

With this patch, the API uses the API URL as the schemas URL if it ends with `/schemas`.

Granted, this should be fixed in Rancher server instead, but at least this PR makes the catalog API usable without upgrading production servers (unless I'm missing something in the docs).
