### PR TITLE
Make schema keys case insensitive

### DIFF
--- a/client/schemas.go
+++ b/client/schemas.go
@@ -28,7 +28,7 @@ func (s *Schema) Field(name string) Field {
 
 func (s *Schemas) CheckSchema(name string) (Schema, bool) {
 	for i := range s.Data {
-		if s.Data[i].Id == name {
+		if strings.ToLower(s.Data[i].Id) == strings.ToLower(name) {
 			return s.Data[i], true
 		}
 	}


### PR DESCRIPTION
This affects the api framework. Currently, if you use the api
framework, your schema urls are case sensitive, but with this change,
they are insensitive