### PR TITLE
Ignores lowerCase struct fields.

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -22,8 +22,9 @@ const (
 )
 
 var (
-	debug  = false
-	dialer = &websocket.Dialer{}
+	debug             = false
+	dialer            = &websocket.Dialer{}
+	privateFieldRegex = regexp.MustCompile("^[[:lower:]]")
 )
 
 type ClientOpts struct {

--- a/client/schemas.go
+++ b/client/schemas.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 )
 
@@ -42,6 +43,7 @@ func (s *Schemas) Schema(name string) Schema {
 
 func typeToFields(t reflect.Type) map[string]Field {
 	result := map[string]Field{}
+	re := regexp.MustCompile("^[[:lower:]]")
 
 	for i := 0; i < t.NumField(); i++ {
 		schemaField := Field{}
@@ -55,6 +57,8 @@ func typeToFields(t reflect.Type) map[string]Field {
 			result = parentFields
 			continue
 		} else if typeField.Anonymous {
+			continue
+		} else if re.FindStringIndex(typeField.Name) != nil {
 			continue
 		}
 

--- a/client/schemas.go
+++ b/client/schemas.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"reflect"
-	"regexp"
 	"strings"
 )
 
@@ -43,7 +42,6 @@ func (s *Schemas) Schema(name string) Schema {
 
 func typeToFields(t reflect.Type) map[string]Field {
 	result := map[string]Field{}
-	re := regexp.MustCompile("^[[:lower:]]")
 
 	for i := 0; i < t.NumField(); i++ {
 		schemaField := Field{}
@@ -58,7 +56,7 @@ func typeToFields(t reflect.Type) map[string]Field {
 			continue
 		} else if typeField.Anonymous {
 			continue
-		} else if re.FindStringIndex(typeField.Name) != nil {
+		} else if privateFieldRegex.FindStringIndex(typeField.Name) != nil {
 			continue
 		}
 

--- a/v2/common.go
+++ b/v2/common.go
@@ -24,8 +24,9 @@ const (
 )
 
 var (
-	debug  = false
-	dialer = &websocket.Dialer{}
+	debug             = false
+	dialer            = &websocket.Dialer{}
+	privateFieldRegex = regexp.MustCompile("^[[:lower:]]")
 )
 
 type ClientOpts struct {

--- a/v2/schemas.go
+++ b/v2/schemas.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 )
 
@@ -42,6 +43,7 @@ func (s *Schemas) Schema(name string) Schema {
 
 func typeToFields(t reflect.Type) map[string]Field {
 	result := map[string]Field{}
+	re := regexp.MustCompile("^[[:lower:]]")
 
 	for i := 0; i < t.NumField(); i++ {
 		schemaField := Field{}
@@ -55,6 +57,8 @@ func typeToFields(t reflect.Type) map[string]Field {
 			result = parentFields
 			continue
 		} else if typeField.Anonymous {
+			continue
+		} else if re.FindStringIndex(typeField.Name) != nil {
 			continue
 		}
 

--- a/v2/schemas.go
+++ b/v2/schemas.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"reflect"
-	"regexp"
 	"strings"
 )
 
@@ -43,7 +42,6 @@ func (s *Schemas) Schema(name string) Schema {
 
 func typeToFields(t reflect.Type) map[string]Field {
 	result := map[string]Field{}
-	re := regexp.MustCompile("^[[:lower:]]")
 
 	for i := 0; i < t.NumField(); i++ {
 		schemaField := Field{}
@@ -58,7 +56,7 @@ func typeToFields(t reflect.Type) map[string]Field {
 			continue
 		} else if typeField.Anonymous {
 			continue
-		} else if re.FindStringIndex(typeField.Name) != nil {
+		} else if privateFieldRegex.FindStringIndex(typeField.Name) != nil {
 			continue
 		}
 


### PR DESCRIPTION
This changes the behavior so that structs passed with unexported fields do not get added to the schema. This follows the behavior of the Json marshaling in golang.