### PR TITLE
StartOnCreate should be a pointer to bool

### DIFF
--- a/scripts/gen-schema.sh
+++ b/scripts/gen-schema.sh
@@ -27,6 +27,8 @@ gen() {
     go run generator.go
     echo " Done"
 
+    find ../v2 -type f -exec sed -i -e 's/StartOnCreate bool/StartOnCreate *bool/g' {} \;
+
     gofmt -w ../v2/generated_*
     echo Formatted code
 


### PR DESCRIPTION
It's not possible to pass `false` to `startOnCreate` because of `omitempty`. Changing this to a pointer is the best method I know of to make this possible.

This doesn't actually commit any of the generated changes since there are various updates and I'm not sure what should/shouldn't be committed.