### PR TITLE
Schema generation script changes: support code generation for a different schema endpoint

### DIFF
--- a/scripts/common_functions
+++ b/scripts/common_functions
@@ -8,3 +8,28 @@ set_project_vars()
 
     export GOPATH=$(pwd)/Godeps/_workspace:$(pwd)/gopath
 }
+
+gen() {
+    BASE=$1
+
+    curl -s "$BASE/schemas?_role=service" | jq . > schemas.json
+    echo Saved schemas.json
+
+    echo -n Generating go code...
+    rm -rf ../v2/generated_* || true
+    go run generator.go
+    echo " Done"
+
+    gofmt -w ../v2/generated_*
+    echo Formatted code
+
+    if [ -n "$2" ]; then
+        rm -rf ../$2
+        mv ../v2 ../$2
+        if [ -n "$3" ]; then
+            sed -i -e 's/package client/package '$2'/g' ../$2/*.go
+        fi
+        git checkout ../v2
+    fi
+    rm schemas.json
+}

--- a/scripts/gen-schema.sh
+++ b/scripts/gen-schema.sh
@@ -1,47 +1,27 @@
 #!/bin/bash
+usage()
+{
+   echo "Usage: $0 <url_to_schema> <folder_to_save_generated_files>"
+   echo "Usage: Do not use folder name as 'client' or 'v2'"
+   exit 1
+}
+
+if [ "$#" -ne 2 ]
+then
+  usage
+fi
+
+if [ "$2" == "client" ] || [ "$2" == "v2" ]
+then
+  usage
+fi
+
 set -e -x
 
 cd $(dirname $0)/../generator
 
-URL_BASE='http://localhost:8080'
+source $(dirname "$0")/../scripts/common_functions
 
-if [ "$1" != "" ]; then
-    URL_BASE=$1
-fi
-
-echo -n Waiting for cattle ${URL_BASE}/ping
-while ! curl -fs ${URL_BASE}/ping; do
-    echo -n .
-    sleep 1
-done
-echo
-
-gen() {
-    BASE=$1
-
-    curl -s "${URL_BASE}/$BASE/schemas?_role=service" | jq . > schemas.json
-    echo Saved schemas.json
-
-    echo -n Generating go code...
-    rm -rf ../v2/generated_* || true
-    go run generator.go
-    echo " Done"
-
-    gofmt -w ../v2/generated_*
-    echo Formatted code
-
-    if [ -n "$2" ]; then
-        rm -rf ../$2
-        mv ../v2 ../$2
-        if [ -n "$3" ]; then
-            sed -i -e 's/package client/package '$2'/g' ../$2/*.go
-        fi
-        git checkout ../v2
-    fi
-    rm schemas.json
-}
-
-gen v1-catalog catalog rename
-gen v2-beta
+gen $1 $2 rename
 
 echo Success

--- a/scripts/generate-rancher-schemas.sh
+++ b/scripts/generate-rancher-schemas.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e -x
+
+cd $(dirname $0)/../generator
+
+URL_BASE='http://localhost:8080'
+
+if [ "$1" != "" ]; then
+    URL_BASE=$1
+fi
+
+echo -n Waiting for cattle ${URL_BASE}/ping
+while ! curl -fs ${URL_BASE}/ping; do
+    echo -n .
+    sleep 1
+done
+echo
+
+source $(dirname "$0")/../scripts/common_functions
+
+gen ${URL_BASE}/v1-catalog catalog rename
+gen ${URL_BASE}/v2-beta
+
+echo Success


### PR DESCRIPTION
Script to generate the schemas has been separated into two scripts:

1) Use generate-rancher-schemas.sh to generate the cattle(v2-beta) and
catalog(v1-catalog) schemas
2) Use gen-schema.sh <url_to_schema> <folder_to_save_generated_files> to
generate schema for any other schema endpoint