### PR TITLE
getCollection for v2

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -43,12 +43,15 @@ func getEmbedded(obj interface{}, checkType reflect.Type) interface{} {
 	return nil
 }
 
-func getCollection(obj interface{}) *client.Collection {
+func getCollection(obj interface{}) interface{} {
 	val := getEmbedded(obj, reflect.TypeOf(client.Collection{}))
 	if val == nil {
-		return nil
+		val = getEmbedded(obj, reflect.TypeOf(v2client.Collection{}))
+		if val == nil {
+			return nil
+		}
 	}
-	return val.(*client.Collection)
+	return val
 }
 
 func getResource(obj interface{}) (*client.Resource, *v2client.Resource) {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8744
rancher-auth-service uses v2 client.Identity. `getResource` has been modified but `getCollection` should be changed too.