### PR TITLE
Add drainTimeoutMs field to go-rancher v2

### DIFF
--- a/v2/generated_launch_config.go
+++ b/v2/generated_launch_config.go
@@ -79,6 +79,8 @@ type LaunchConfig struct {
 
 	DomainName string `json:"domainName,omitempty" yaml:"domain_name,omitempty"`
 
+	DrainTimeoutMs int64 `json:"drainTimeoutMs,omitempty" yaml:"drain_timeout_ms,omitempty"`
+
 	EntryPoint []string `json:"entryPoint,omitempty" yaml:"entry_point,omitempty"`
 
 	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`

--- a/v2/generated_secondary_launch_config.go
+++ b/v2/generated_secondary_launch_config.go
@@ -79,6 +79,8 @@ type SecondaryLaunchConfig struct {
 
 	DomainName string `json:"domainName,omitempty" yaml:"domain_name,omitempty"`
 
+	DrainTimeoutMs int64 `json:"drainTimeoutMs,omitempty" yaml:"drain_timeout_ms,omitempty"`
+
 	EntryPoint []string `json:"entryPoint,omitempty" yaml:"entry_point,omitempty"`
 
 	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`


### PR DESCRIPTION
Add new field drainTimeoutMs to go-rancher v2 "launch_config" and "secondary_launch_config"